### PR TITLE
Add support NextLink and other custom link components

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -50,6 +50,7 @@ export interface ButtonProps extends DOMProps, QAProps {
     type?: 'button' | 'submit' | 'reset';
     component?: React.ElementType;
     href?: string;
+    hrefComponent?: React.ElementType;
     target?: string;
     rel?: string;
     extraProps?:
@@ -80,6 +81,7 @@ const ButtonWithHandlers = React.forwardRef<HTMLElement, ButtonProps>(function B
         type = 'button',
         component,
         href,
+        hrefComponent,
         target,
         rel,
         extraProps,
@@ -137,14 +139,17 @@ const ButtonWithHandlers = React.forwardRef<HTMLElement, ButtonProps>(function B
         'data-qa': qa,
     };
 
-    if (typeof href === 'string' || component) {
+    if (href || component) {
         const linkProps = {
             href,
             target,
             rel: target === '_blank' && !rel ? 'noopener noreferrer' : rel,
         };
+
+        const LinkComponent = hrefComponent || 'a';
+
         return React.createElement(
-            component || 'a',
+            component || LinkComponent,
             {
                 ...extraProps,
                 ...commonProps,


### PR DESCRIPTION
Added support for using custom link components (e.g., NextLink) in the Button component via the new `hrefComponent` prop. If `hrefComponent` is not specified, it defaults to `<a>`.

**Details:**
- Introduced a new prop `hrefComponent` in `ButtonProps`.
- If `hrefComponent` is provided, it will render the specified component for links instead of  `<a>`.
- Maintains backward compatibility by defaulting to `<a>` when `hrefComponent` is not set.
- Ensures flexibility for projects using custom routing libraries like Next.js.